### PR TITLE
Update Android Plugin for Gradle to 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 


### PR DESCRIPTION
As the title says, this PR switches from Android Plugin for Gradle version 2.0.0 over to 2.1.0 which was released in April. Looks like a perfectly safe switch to me.