### PR TITLE
Add support for version 11.25.55

### DIFF
--- a/youtube_hooks.json
+++ b/youtube_hooks.json
@@ -395,5 +395,16 @@
         "FIELD_2": "c",
         "CLASS_3": "ccs",
         "METHOD_3": "d"
+    },
+    "112555": {
+        "CLASS_1": "qrg",
+        "METHOD_1": "e",
+        "FIELD_1": "i",
+        "SUBFIELD_1": "f",
+        "CLASS_2": "nhe",
+        "METHOD_2": "a",
+        "FIELD_2": "c",
+        "CLASS_3": "ceh",
+        "METHOD_3": "d"
     }
 }


### PR DESCRIPTION
This commit simply adds support for version 11.25.55 of
the YouTube application. Rejoice!