### PR TITLE
decrease reliance on version_multiplier

### DIFF
--- a/java/com/pyler/youtubebackgroundplayback/YouTubeBackgroundPlayback.java
+++ b/java/com/pyler/youtubebackgroundplayback/YouTubeBackgroundPlayback.java
@@ -65,9 +65,15 @@ public class YouTubeBackgroundPlayback implements IXposedHookLoadPackage {
 		final Object activityThread = callStaticMethod(findClass("android.app.ActivityThread", null), "currentActivityThread");
 		final Context context = (Context) callMethod(activityThread, "getSystemContext");
 		final int versionCode = context.getPackageManager().getPackageInfo(APP_PACKAGE, 0).versionCode;
-		final String version = Integer.toString(versionCode / (versionMultiplier < 1 ? 1 : versionMultiplier), 10);
-
+		String version = Integer.toString(versionCode / (versionMultiplier < 1 ? 1 : versionMultiplier), 10);
 		JSONArray hooks = hooksFile.optJSONArray(version);
+		
+		if(hooks == null) {
+			version	= Integer.toString(versionCode).substring(0, 6);
+			hooks = hooksFile.optJSONArray(version);
+			if(hooks != null) Log.i(LOG_TAG, "Wrong version multiplier " + versionMultiplier + "? [vc:" + versionCode + "]");
+		}
+	
 		if (hooks == null) {
 			Log.i(LOG_TAG, "No hook details were found for the version of YouTube installed on your device. [vc:" + versionCode + "]");
 			hooks = hooksFile.optJSONArray("fallback");


### PR DESCRIPTION
Needs an APK update! This assumes that versions are six-digit so you might consider it a bit hacky. It worked on 12.19.56 before th3an7 changed it to "1219560" (which doesn't work because it needs to be both "1219562" and "1219563", or if this PR is pulled, just "121956", so that would have to be changed back).